### PR TITLE
 Put depends build fallback into Actions instead of docker.sh

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,9 +73,7 @@ jobs:
             echo "PECAN_TAGS=develop" >> $GITHUB_ENV
           fi
       # If any dependencies changed in this PR, try to update depends image
-      # Only runs on pull_request -- others it's not clear what base to compare to
       - name: check for changed dependencies
-        if: github.base_ref != ''
         uses: dorny/paths-filter@v3
         id: findchanges
         with:
@@ -83,7 +81,14 @@ jobs:
             deps:
               - docker/depends/**
       - if: steps.findchanges.outputs.deps == 'true'
-        run: echo "UPDATE_DEPENDS_FROM_TAG=${GITHUB_BASE_REF##*/}" >> $GITHUB_ENV
+        # NB: GITHUB_BASE_REF is only set on pull requests,
+        # so non-PR builds will find no existing tag and build fresh
+        run: |
+          if $(docker manifest inspect pecan/depends:${GITHUB_BASE_REF##*/} > /dev/null 2>&1); then
+            echo "UPDATE_DEPENDS_FROM_TAG=${GITHUB_BASE_REF##*/}" >> $GITHUB_ENV
+          else
+            echo "BUILD_DEPENDS_FRESH=true" >> GITHUB_ENV
+          fi
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
       # use shell script to build, there is some complexity in this
@@ -94,6 +99,7 @@ jobs:
           PECAN_GIT_BRANCH: ${GITHUB_BRANCH}
           VERSION: ${{ env.PECAN_VERSION }}
           UPDATE_DEPENDS_FROM_TAG: ${{ env.UPDATE_DEPENDS_FROM_TAG }}
+          BUILD: ${{ env.BUILD_DEPENDS_FRESH }}
 
       # push all images to github
       - name: Publish to GitHub


### PR DESCRIPTION
Possible replacement for https://github.com/robkooper/pecan/pull/79 -- I think either should work; merge the one you like better and close the other.

Note that this one will change behavior of non-PR calls to the Docker action while https://github.com/robkooper/pecan/pull/79 won't:

Status quo:
- Non-PR Action runs with dependency changes do not build depends (which may or may not cause other failures)
- PRS with dependency changes try to build depends (and fail if no tag matches the base ref)

PR 79:
- Non-PR Action runs with dependency changes do not build depends (which may or may not cause other failures)
- PRS with dependency changes try to build depends (and fall back to a clean build if no tag matches the base ref)

This PR:
- Non-PR Action runs with dependency changes build depends from scratch
- PRS with dependency changes try to build depends (and fall back to a clean build if no tag matches the base ref)

Invariant across all 3 approaches: Runs with no dependency changes do not build depends, whether or not they're a PR.